### PR TITLE
Set PermGen space so compilation doesn't fail w/ Java7

### DIFF
--- a/sbt.sh
+++ b/sbt.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -Xmx3g -Xms3g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar "$@"
+java -Xmx3g -Xms3g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M -jar sbt-launch.jar "$@"


### PR DESCRIPTION
Myself and a few peers had trouble running the getting started:

``` bash
exercises!essential-scala-code> ./sbt.sh
[info] Loading project definition from /Users/jacques/code/simple/essential-scala-code/project
[info] Set current project to essential-scala-code (in build file:/Users/jacques/code/simple/essential-scala-code/)
> runMain intro.HelloWorld
[info] Compiling 13 Scala sources to /Users/jacques/code/simple/essential-scala-code/target/scala-2.11/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.11.8. Compiling...
[info]   Compilation completed in 6.842 s
java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: PermGen space
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:188)
    at sbt.ConcurrentRestrictions$$anon$4.take(ConcurrentRestrictions.scala:188)
    at sbt.Execute.next$1(Execute.scala:83)
    at sbt.Execute.processAll(Execute.scala:86)
    at sbt.Execute.runKeep(Execute.scala:66)
    at sbt.EvaluateTask$.liftedTree1$1(EvaluateTask.scala:359)
    at sbt.EvaluateTask$.run$1(EvaluateTask.scala:358)
    at sbt.EvaluateTask$.runTask(EvaluateTask.scala:378)
    at sbt.Aggregation$$anonfun$3.apply(Aggregation.scala:64)
    at sbt.Aggregation$$anonfun$3.apply(Aggregation.scala:62)
    at sbt.EvaluateTask$.withStreams(EvaluateTask.scala:314)
    at sbt.Aggregation$.timedRun(Aggregation.scala:62)
    at sbt.Aggregation$.runTasks(Aggregation.scala:71)
    at sbt.Aggregation$$anonfun$applyDynamicTasks$1.apply(Aggregation.scala:112)
    at sbt.Aggregation$$anonfun$applyDynamicTasks$1.apply(Aggregation.scala:110)
    at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
    at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
    at sbt.Act$$anonfun$sbt$Act$$actParser0$1$$anonfun$sbt$Act$$anonfun$$evaluate$1$1$$anonfun$apply$10.apply(Act.scala:244)
    at sbt.Act$$anonfun$sbt$Act$$actParser0$1$$anonfun$sbt$Act$$anonfun$$evaluate$1$1$$anonfun$apply$10.apply(Act.scala:241)
    at sbt.Command$.process(Command.scala:93)
    at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:98)
    at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:98)
    at sbt.State$$anon$1.process(State.scala:184)
    at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:98)
    at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:98)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.MainLoop$.next(MainLoop.scala:98)
    at sbt.MainLoop$.run(MainLoop.scala:91)
    at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:70)
    at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:65)
    at sbt.Using.apply(Using.scala:24)
    at sbt.MainLoop$.runWithNewLog(MainLoop.scala:65)
    at sbt.MainLoop$.runAndClearLast(MainLoop.scala:48)
    at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:32)
    at sbt.MainLoop$.runLogged(MainLoop.scala:24)
    at sbt.StandardMain$.runManaged(Main.scala:53)
    at sbt.xMain.run(Main.scala:28)
    at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
    at xsbt.boot.Launch$.withContextLoader(Launch.scala:129)
    at xsbt.boot.Launch$.run(Launch.scala:109)
    at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:36)
    at xsbt.boot.Launch$.launch(Launch.scala:117)
    at xsbt.boot.Launch$.apply(Launch.scala:19)
    at xsbt.boot.Boot$.runImpl(Boot.scala:44)
#!/usr/bin/env bash
    at xsbt.boot.Boot$.main(Boot.scala:20)
    at xsbt.boot.Boot.main(Boot.scala)
Caused by: java.lang.OutOfMemoryError: PermGen space
    at java.io.ObjectOutputStream.<init>(ObjectOutputStream.java:243)
    at xsbt.api.SourceFormat$.writes(SourceFormat.scala:23)
    at xsbt.api.SourceFormat$.writes(SourceFormat.scala:15)
    at sbt.inc.TextAnalysisFormat$ObjectStringifier$$anonfun$objToString$1.apply$mcV$sp(TextAnalysisFormat.scala:330)
    at sbt.inc.TextAnalysisFormat$ObjectStringifier$$anonfun$objToString$1.apply(TextAnalysisFormat.scala:330)
    at sbt.inc.TextAnalysisFormat$ObjectStringifier$$anonfun$objToString$1.apply(TextAnalysisFormat.scala:330)
    at sbt.inc.FormatTimer$.aggregate(TextAnalysisFormat.scala:18)
    at sbt.inc.TextAnalysisFormat$ObjectStringifier$.objToString(TextAnalysisFormat.scala:330)
    at sbt.inc.TextAnalysisFormat$APIsF$$anonfun$15.apply(TextAnalysisFormat.scala:213)
    at sbt.inc.TextAnalysisFormat$APIsF$$anonfun$15.apply(TextAnalysisFormat.scala:213)
    at sbt.inc.TextAnalysisFormat$$anonfun$sbt$inc$TextAnalysisFormat$$writeMap$1.apply(TextAnalysisFormat.scala:386)
    at sbt.inc.TextAnalysisFormat$$anonfun$sbt$inc$TextAnalysisFormat$$writeMap$1.apply(TextAnalysisFormat.scala:382)
    at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
    at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
    at sbt.inc.TextAnalysisFormat$.sbt$inc$TextAnalysisFormat$$writeMap(TextAnalysisFormat.scala:382)
    at sbt.inc.TextAnalysisFormat$APIsF$.write(TextAnalysisFormat.scala:216)
    at sbt.inc.TextAnalysisFormat$$anonfun$write$4.apply$mcV$sp(TextAnalysisFormat.scala:64)
    at sbt.inc.TextAnalysisFormat$$anonfun$write$4.apply(TextAnalysisFormat.scala:64)
    at sbt.inc.TextAnalysisFormat$$anonfun$write$4.apply(TextAnalysisFormat.scala:64)
    at sbt.inc.FormatTimer$.aggregate(TextAnalysisFormat.scala:18)
    at sbt.inc.FormatTimer$.time(TextAnalysisFormat.scala:25)
    at sbt.inc.TextAnalysisFormat$.write(TextAnalysisFormat.scala:64)
[core]
    at sbt.inc.FileBasedStore$$anon$1$$anonfun$set$1.apply(FileBasedStore.scala:12)
    at sbt.inc.FileBasedStore$$anon$1$$anonfun$set$1.apply(FileBasedStore.scala:12)
    at sbt.Using.apply(Using.scala:24)
    at sbt.inc.FileBasedStore$$anon$1.set(FileBasedStore.scala:12)
    at sbt.inc.AnalysisStore$$anon$1.set(AnalysisStore.scala:16)
    at sbt.inc.AnalysisStore$$anon$2.set(AnalysisStore.scala:27)
    at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:814)
    at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:808)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
[error] java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: PermGen space
[error] Use 'last' for the full log.
```

At least one person using java8 didn't hit this issue.
